### PR TITLE
Support ModelName Settings 

### DIFF
--- a/components/components/SettingsDialog.tsx
+++ b/components/components/SettingsDialog.tsx
@@ -99,6 +99,22 @@ function SettingsDialog({ settings, setSettings, openDialog, setOpenDialog }: Pr
                 <RadioGroupItem  value="gemini" id="gemini-llm"/>
               </Label>
             </RadioGroup>
+            <div>
+              <Label >
+                Model Name (optional)
+              </Label>
+              <Input
+                  id="model-name"
+                  placeholder="Model Name"
+                  value={settings?.modelName || ""}
+                  onChange={(e) =>
+                    setSettings({
+                      ...settings,
+                      modelName: e.target.value,
+                    })
+                  }
+                />
+            </div>
           </div>
           {
             settings.llm === 'openai' ? (

--- a/components/contexts/SettingContext.tsx
+++ b/components/contexts/SettingContext.tsx
@@ -26,6 +26,7 @@ const initialValue = {
         init: false,
         llm: 'openai',
         geminiApiKey: '',
+        modelName: '',
     },
     initCreate: false,
     setSettings: () => {},

--- a/components/types.ts
+++ b/components/types.ts
@@ -32,6 +32,7 @@ export interface Settings {
   init: boolean;
   llm: string;
   geminiApiKey: string;
+  modelName: string | null;
 }
 
 export enum AppState {

--- a/service/events/generateCode.ts
+++ b/service/events/generateCode.ts
@@ -21,6 +21,7 @@ export interface IGenerateCodeParams {
   llm: string;
   geminiApiKey: string;
   slug?: string;
+  modelName: string;
 }
 
 const encoder = new TextEncoder();
@@ -118,6 +119,7 @@ export async function streamGenerateCode(
           openAiBaseURL: params.openAiBaseURL,
           llm: params.llm, // 'Gemini'
           geminiApiKey: params.geminiApiKey,
+          modelName: params.modelName,
         },
       );
     } catch (e) {

--- a/service/events/llm.ts
+++ b/service/events/llm.ts
@@ -95,6 +95,10 @@ async function useGeminiResponse([messages, callback, params]: Parameters<
     modelType = "gemini-pro-vision"
   }
 
+  if (params.modelName) {
+    modelType = params.modelName
+  }
+
   const model = genAI.getGenerativeModel({ model:  modelType});
 
   const result = await model.generateContentStream({
@@ -133,6 +137,7 @@ export async function streamingOpenAIResponses(
     openAiBaseURL: any;
     llm: string;
     geminiApiKey: any;
+    modelName: any;
   }
 ) {
 
@@ -153,8 +158,13 @@ export async function streamingOpenAIResponses(
       'https://api.openai.com/v1',
   });
 
+  let modelName = 'gpt-4-vision';
+  if (params.modelName) {
+    modelName = params.modelName;
+  }
+
   const stream = await openai.chat.completions.create({
-    model: 'gpt-4-vision-preview',
+    model: modelName,
     temperature: 0,
     max_tokens: 4096,
     messages,


### PR DESCRIPTION
User can config the `Model Name` in Settings to test GPT4-o or other new models like below:

![image](https://github.com/sparrow-js/an-codeAI/assets/11539396/09a183d7-7b81-44c3-9d0f-e7ac20cd79c0)

and the default value keep the same as before.


for #90 